### PR TITLE
Add displayName to the Wrapper component of connectWithTheme

### DIFF
--- a/src/styles/theme/connect-with-theme.jsx
+++ b/src/styles/theme/connect-with-theme.jsx
@@ -30,5 +30,11 @@ export default function connectWithTheme(Component, componentName = null) {
 
   Wrapper.contextTypes = { theme: PropTypes.object };
 
+  const displayName = Component.displayName || Component.name || 'Component';
+
+  Wrapper.displayName = displayName.startsWith('Jss')
+    ? `connectWithTheme(${displayName.slice(4, displayName.length - 1)})`
+    : `connectWithTheme(${displayName})`;
+
   return Wrapper;
 }


### PR DESCRIPTION
Add a more descriptive displayName than Wrapper

Example:
- Progress => connectWithTheme(Progress)
- Jss(Button) => connectWithTheme(Button)