### PR TITLE
Fix the props of the Ripple inside of the Switch component

### DIFF
--- a/src/components/switch/switch.jsx
+++ b/src/components/switch/switch.jsx
@@ -63,6 +63,8 @@ export function Switch(props) {
           onPress={onPress}
         >
           <Ripple
+            round
+            center
             nowaves={noink}
             focusColor={rippleFocusColor}
             color={rippleColor}


### PR DESCRIPTION
Missing center and round props made the ripple look weird