### PR TITLE
Updated Spinner to not use web animations

### DIFF
--- a/src/components/spinner/spinner.jsx
+++ b/src/components/spinner/spinner.jsx
@@ -14,7 +14,6 @@ import { easeInOutCubic } from '../../styles/timings';
 export class Spinner extends PureComponent {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    theme: PropTypes.object.isRequired,
     active: PropTypes.bool,
     className: PropTypes.string,
   };
@@ -66,6 +65,8 @@ export class Spinner extends PureComponent {
         height: theme.size,
         padding: 8,
         boxSizing: 'border-box',
+        opacity: 0,
+        transition: `opacity ${theme.fadeInOutDuration / 2}ms ${easeInOutCubic}`,
 
         '&.spinner--active $container': { animationName: 'spinner--container-rotate' },
 
@@ -182,11 +183,7 @@ export class Spinner extends PureComponent {
     }
   }
 
-  animationOptions = {
-    duration: this.props.theme.spinner.expandContractDuration / 2,
-    easing: easeInOutCubic,
-    fill: 'forwards',
-  };
+  removeActiveClass = false;
 
   /**
    * Fade the spinner in.
@@ -196,7 +193,7 @@ export class Spinner extends PureComponent {
   fadeIn() {
     this.root.classList.add('spinner--active');
 
-    this.root.animate({ opacity: [0, 1] }, this.animationOptions);
+    this.root.style.opacity = 1;
   }
 
   /**
@@ -205,24 +202,35 @@ export class Spinner extends PureComponent {
    * @private
    */
   fadeOut() {
-    this.anim = this.root.animate({ opacity: [1, 0] }, this.animationOptions);
+    this.removeActiveClass = true;
 
-    this.anim.onfinish = () => this.root.classList.remove('spinner--active');
+    this.root.style.opacity = 0;
   }
+
+  /**
+   * When the transition ends we need to check if we should handle the event
+   * and remove the .spinner--active class.
+   */
+  handleTransitionEnd = () => {
+    if (this.removeActiveClass) {
+      this.removeActiveClass = false;
+
+      this.root.classList.remove('spinner--active');
+    }
+  };
 
   render() {
     const { classes } = this.props;
 
     return (
       <div
+        role="presentation"
         {...getNotDeclaredProps(this.props, Spinner)}
         className={`${classes.spinner} ${this.props.className}`}
         ref={(element) => { this.root = element; }}
+        onTransitionEnd={this.handleTransitionEnd}
       >
-        <div
-          className={classes.container}
-          ref={(element) => { this.container = element; }}
-        >
+        <div className={classes.container}>
           <div className={classes.layer}>
             <div className={`${classes.clipper} ${classes.clipperLeft}`} />
             <div className={`${classes.clipper} ${classes.clipperRight}`} />

--- a/src/components/spinner/spinner.spec.js
+++ b/src/components/spinner/spinner.spec.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import React from 'react';
 
 import { mount } from '../../../tests/helpers/enzyme';
-import SpinnerWrapper, { Spinner } from './spinner';
+import SpinnerWrapper from './spinner';
 
 test('should render a div with an svg inside', (t) => {
   const wrapper = mount(<SpinnerWrapper />);
@@ -30,23 +30,20 @@ test('should fade the spinner in/out when the active prop changes', (t) => {
   t.deepEqual(root().node.style.opacity, '0');
 });
 
-test('should remove the active class after the fade out animation finishes', (t) => {
-  const wrapper = mount(
-    <Spinner
-      active
-      classes={{ spinner: 'spinner' }}
-      theme={{ spinner: {} }}
-    />,
-  );
-  const instance = wrapper.instance();
+test('should remove the active class when the transition end handler get\'s called', (t) => {
+  const wrapper = mount(<SpinnerWrapper />);
 
-  instance.fadeOut();
+  wrapper.setProps({ active: true });
 
-  instance.anim.onfinish();
+  wrapper.simulate('transitionEnd');
+
+  wrapper.setProps({ active: false });
+
+  wrapper.simulate('transitionEnd');
 
   const root = wrapper.find('.spinner');
 
-  t.deepEqual(root.node.classList.contains('spinner--active'), false);
+  t.true(!root.node.classList.contains('spinner--active'));
 });
 
 test('should not update the opacity of the spinner when the active prop doesn\'t changes', (t) => {

--- a/src/components/spinner/theme.js
+++ b/src/components/spinner/theme.js
@@ -7,6 +7,7 @@ export const schema = PropTypes.shape({
   color: PropTypes.string.isRequired,
   strokeWidth: PropTypes.number.isRequired,
   size: PropTypes.number.isRequired,
+  fadeInOutDuration: PropTypes.number.isRequired,
 });
 
 /**
@@ -23,5 +24,6 @@ export function defaultTheme(vars) {
     color: vars.primaryBase,
     strokeWidth: 4,
     size: 56,
+    fadeInOutDuration: 1333 / 3,
   };
 }


### PR DESCRIPTION
Switch from WebAnimationsJs to the more traditional transition.
This should reduce the complexity of the code and slightly improve performance. 