### PR TITLE
Remove web animations js

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "randomstring": "1.1.5",
     "react": "15.6.1",
     "react-get-not-declared-props": "0.2.0",
-    "react-jss": "7.0.2",
-    "web-animations-js": "2.2.5"
+    "react-jss": "7.0.2"
   },
   "devDependencies": {
     "@storybook/addon-actions": "3.1.9",

--- a/src/components/checkbox/checkbox.jsx
+++ b/src/components/checkbox/checkbox.jsx
@@ -44,6 +44,28 @@ export class Checkbox extends PureComponent {
     const { disabledCheckedBgColor } = theme;
 
     return {
+      '@keyframes checkbox--animate-in': {
+        from: {
+          opacity: 1,
+          transform: 'scale(0) rotate(-45deg)',
+        },
+        to: {
+          opacity: 1,
+          transform: 'scale(1) rotate(45deg)',
+        },
+      },
+
+      '@keyframes checkbox--animate-out': {
+        from: {
+          opacity: 1,
+          transform: 'scale(1) rotate(45deg)',
+        },
+        to: {
+          opacity: 0,
+          transform: 'scale(1) rotate(45deg)',
+        },
+      },
+
       checkbox: {
         composes: 'checkbox',
         boxSizing: 'border-box',
@@ -119,6 +141,9 @@ export class Checkbox extends PureComponent {
         boxSizing: 'content-box',
         willChange: 'opacity, transform',
         opacity: 0,
+        animationDuration: `${theme.animationDuration}ms`,
+        animationFillMode: 'forwards',
+        animationTimingFunction: easeInOutCubic,
       },
     };
   }
@@ -133,7 +158,7 @@ export class Checkbox extends PureComponent {
     this.checkmark.style.borderColor = bgColor;
 
     if (this.props.checked) {
-      this.animateCheckmark();
+      this.checkmark.style.animationName = 'checkbox--animate-in';
     }
   }
 
@@ -142,7 +167,11 @@ export class Checkbox extends PureComponent {
    */
   componentDidUpdate(prevProps) {
     if (prevProps.checked !== this.props.checked) {
-      this.animateCheckmark();
+      if (this.props.checked) {
+        this.checkmark.style.animationName = 'checkbox--animate-in';
+      } else {
+        this.checkmark.style.animationName = 'checkbox--animate-out';
+      }
     }
   }
 
@@ -161,22 +190,6 @@ export class Checkbox extends PureComponent {
       color: checked ? theme.checkedBorderColor : theme.uncheckedBorderColor,
       focusColor: checked ? theme.checkedBorderColor : theme.uncheckedBorderColor,
     };
-  }
-
-  /**
-   * Animate the checkmark either in or out.
-   */
-  animateCheckmark() {
-    const animations = this.props.checked ? {
-      opacity: [1, 1],
-      transform: ['scale(0, 0) rotate(-45deg)', 'scale(1, 1) rotate(45deg)'],
-    } : { opacity: [1, 0] };
-
-    this.checkmark.animate(animations, {
-      easing: easeInOutCubic,
-      fill: 'forwards',
-      duration: this.props.theme.checkbox.animationDuration,
-    });
   }
 
   /**

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -1,21 +1,18 @@
 import React from 'react';
 import test from 'ava';
-import sinon from 'sinon';
 
-import CheckboxWrapper, { Checkbox } from './checkbox';
+import CheckboxWrapper from './checkbox';
 import { mount } from '../../../tests/helpers/enzyme';
 
 const defaultProps = {
-  classes: {},
-  theme: { checkbox: {} },
   checked: false,
   disabled: false,
   className: '',
   isFocused: false,
-  onPress: () => {},
   id: 'id',
   children: '',
   labelPosition: 'right',
+  onPress: () => {},
   onKeyPress: () => {},
   onFocus: () => {},
   onBlur: () => {},
@@ -29,29 +26,28 @@ test('should render a span with a role of checkbox and a Jss HoC', (t) => {
 });
 
 test('should animate the checkmark when the checked prop is initially passed', (t) => {
-  const spy = sinon.spy(Checkbox.prototype, 'animateCheckmark');
-
-  mount(
+  const wrapper = mount(
     <CheckboxWrapper
       {...defaultProps}
       checked
     />,
   );
+  const checkmark = wrapper.find('.checkbox--checkmark').node;
 
-  t.true(spy.calledOnce);
+  t.deepEqual(checkmark.style.animationName, 'checkbox--animate-in');
 });
 
-test('should call the animateCheckmark when the checked prop changes', (t) => {
+test('should change the animationName when the checked prop changes', (t) => {
   const wrapper = mount(<CheckboxWrapper {...defaultProps} />);
-  const root = () => wrapper.find({ role: 'checkbox' });
+  const checkmark = () => wrapper.find('.checkbox--checkmark').node;
 
   wrapper.setProps({ checked: true });
 
-  t.deepEqual(root().prop('aria-checked'), true);
+  t.deepEqual(checkmark().style.animationName, 'checkbox--animate-in');
 
   wrapper.setProps({ checked: false });
 
-  t.deepEqual(root().prop('aria-checked'), false);
+  t.deepEqual(checkmark().style.animationName, 'checkbox--animate-out');
 });
 
 test('should set the aria-disabled attribute on the root element', (t) => {

--- a/src/components/progress/progress.jsx
+++ b/src/components/progress/progress.jsx
@@ -130,6 +130,7 @@ export class Progress extends PureComponent {
         transformOrigin: 'left center',
         willChange: 'transform',
         transform: 'scaleX(0)',
+        transition: `transform ${easeInOutCubic}`,
         backgroundColor: theme.primaryBarColor,
       },
 
@@ -143,6 +144,7 @@ export class Progress extends PureComponent {
         transformOrigin: 'left center',
         willChange: 'transform',
         transform: 'scaleX(0)',
+        transition: `transform ${easeInOutCubic}`,
         backgroundColor: theme.secondaryBarColor,
       },
     };
@@ -199,21 +201,15 @@ export class Progress extends PureComponent {
    * @param {Number} newProgress - The new progress to animate too.
    */
   animateBar(elem, prevProgress, newProgress) {
-    const transform = window.getComputedStyle(elem).transform;
     const clampNewValue = Progress.clamp(newProgress);
     const clampPrevValue = Progress.clamp(prevProgress);
     const { fullAnimationDuration } = this.props.theme.progress;
+    const duration = Math.abs((clampPrevValue - clampNewValue) / 100) * fullAnimationDuration;
 
-    elem.animate({
-      transform: [
-        transform,
-        `matrix(${clampNewValue / 100}, 0, 0, 1, 0, 0)`,
-      ],
-    }, {
-      fill: 'forwards',
-      duration: Math.abs((clampPrevValue - clampNewValue) / 100) * fullAnimationDuration,
-      easing: easeInOutCubic,
-    });
+    /* eslint-disable no-param-reassign */
+    elem.style.transitionDuration = `${duration}ms`;
+    elem.style.transform = `matrix(${clampNewValue / 100}, 0, 0, 1, 0, 0)`;
+    /* eslint-enable no-param-reassign */
   }
 
   render() {


### PR DESCRIPTION
This removes all of the animate function calls and instead we purely rely on basic CSS transitions and animations.