### PR TITLE
Updated EventHandler

### DIFF
--- a/src/components/event-handler/event-handler.jsx
+++ b/src/components/event-handler/event-handler.jsx
@@ -28,9 +28,11 @@ export default class EventHandler extends PureComponent {
 
   static defaultProps = { children: '' };
 
+  static ignoreMouseEventsAfterTouchFor = 750;
+
   isPressingKey = false;
-  isTouchStartEvent = false;
-  isTouchEndEvent = false;
+  lastTouchStart = false;
+  lastTouchEnd = false;
 
   /**
    * Call the onKeyDown prop if the user passed one
@@ -67,11 +69,9 @@ export default class EventHandler extends PureComponent {
       this.props.onMouseDown(ev);
     }
 
-    if (!this.isTouchStartEvent) {
+    if (ev.timeStamp - this.lastTouchStart > EventHandler.ignoreMouseEventsAfterTouchFor) {
       this.props.onPress(ev);
     }
-
-    this.isTouchStartEvent = false;
   };
 
   /**
@@ -82,11 +82,9 @@ export default class EventHandler extends PureComponent {
       this.props.onMouseUp(ev);
     }
 
-    if (!this.isTouchEndEvent) {
+    if (ev.timeStamp - this.lastTouchEnd > EventHandler.ignoreMouseEventsAfterTouchFor) {
       this.props.onRelease(ev);
     }
-
-    this.isTouchEndEvent = false;
   };
 
   /**
@@ -100,7 +98,7 @@ export default class EventHandler extends PureComponent {
 
     this.props.onPress(ev);
 
-    this.isTouchStartEvent = true;
+    this.lastTouchStart = ev.timeStamp;
   };
 
   /**
@@ -114,7 +112,7 @@ export default class EventHandler extends PureComponent {
 
     this.props.onRelease(ev);
 
-    this.isTouchEndEvent = true;
+    this.lastTouchEnd = ev.timeStamp;
   };
 
   render() {

--- a/src/components/event-handler/event-hanlder.spec.js
+++ b/src/components/event-handler/event-hanlder.spec.js
@@ -5,6 +5,15 @@ import { shallow } from 'enzyme';
 
 import EventHanlder from './event-handler';
 
+/**
+ * Create an event object with the required timeStamp property.
+ *
+ * @returns {Object} - Returns the event object.
+ */
+function createEvent() {
+  return { timeStamp: Date.now() };
+}
+
 test('should call onPress when a mouse or touch event happens', (t) => {
   const onPress = sinon.spy();
   const wrapper = shallow(
@@ -14,11 +23,11 @@ test('should call onPress when a mouse or touch event happens', (t) => {
     />,
   );
 
-  wrapper.simulate('mouseDown');
+  wrapper.simulate('mouseDown', createEvent());
 
   t.deepEqual(onPress.callCount, 1);
 
-  wrapper.simulate('touchStart');
+  wrapper.simulate('touchStart', createEvent());
 
   t.deepEqual(onPress.callCount, 2);
 });
@@ -32,11 +41,11 @@ test('should call onPress only once when a mouse event happens after a touch eve
     />,
   );
 
-  wrapper.simulate('touchStart');
+  wrapper.simulate('touchStart', createEvent());
 
   t.deepEqual(onPress.callCount, 1);
 
-  wrapper.simulate('mouseDown');
+  wrapper.simulate('mouseDown', createEvent());
 
   t.deepEqual(onPress.callCount, 1);
 });
@@ -50,11 +59,11 @@ test('should call onRelease when a mouse or touch event happens', (t) => {
     />,
   );
 
-  wrapper.simulate('mouseUp');
+  wrapper.simulate('mouseUp', createEvent());
 
   t.deepEqual(onRelease.callCount, 1);
 
-  wrapper.simulate('touchEnd');
+  wrapper.simulate('touchEnd', createEvent());
 
   t.deepEqual(onRelease.callCount, 2);
 });
@@ -68,11 +77,11 @@ test('should call onRelease only once when a mouse event happens after a touch e
     />,
   );
 
-  wrapper.simulate('touchEnd');
+  wrapper.simulate('touchEnd', createEvent());
 
   t.deepEqual(onRelease.callCount, 1);
 
-  wrapper.simulate('mouseUp');
+  wrapper.simulate('mouseUp', createEvent());
 
   t.deepEqual(onRelease.callCount, 1);
 });
@@ -91,11 +100,11 @@ test('should call the actual mouse event handlers', (t) => {
     />,
   );
 
-  wrapper.simulate('mouseDown');
+  wrapper.simulate('mouseDown', createEvent());
 
   t.deepEqual(onMouseDown.callCount, 1);
 
-  wrapper.simulate('mouseUp');
+  wrapper.simulate('mouseUp', createEvent());
 
   t.deepEqual(onMouseUp.callCount, 1);
 });
@@ -114,11 +123,11 @@ test('should call the actual touch event handlers', (t) => {
     />,
   );
 
-  wrapper.simulate('touchStart');
+  wrapper.simulate('touchStart', createEvent());
 
   t.deepEqual(onTouchStart.callCount, 1);
 
-  wrapper.simulate('touchEnd');
+  wrapper.simulate('touchEnd', createEvent());
 
   t.deepEqual(onTouchEnd.callCount, 1);
 });


### PR DESCRIPTION
Updated EventHandler to use timestamp instead of ignoring every mouse event after a touch event no matter how much time has passed between them