### PR TITLE
Added better stories for the Drawer component

### DIFF
--- a/src/components/drawer/drawer-container.jsx
+++ b/src/components/drawer/drawer-container.jsx
@@ -22,6 +22,7 @@ import getNotDeclaredProps from '../../get-not-declared-props';
  * Only applies when the drawer is also in narrow mode.
  * @param {Function} props.onBackdropPress - A callback to when the backdrop is pressed.
  * @param {String} props.drawerPosition - The position of the drawer. Either left or right.
+ * @param {Function} props.onTransitionEnd - When the transition of the backdrop has finished.
  * @returns {JSX} - Returns the jsx for the drawer.
  */
 export function DrawerContainer({
@@ -33,6 +34,7 @@ export function DrawerContainer({
   opened,
   drawerPosition,
   onBackdropPress,
+  onTransitionEnd,
   ...props
 }) {
   const className = classNames(classes.drawer, {
@@ -56,6 +58,7 @@ export function DrawerContainer({
           component="span"
           className={classes.backdrop}
           onPress={onBackdropPress}
+          onTransitionEnd={onTransitionEnd}
         />
       )}
     </div>
@@ -76,6 +79,7 @@ DrawerContainer.propTypes = {
   opened: PropTypes.bool.isRequired,
   drawerPosition: PropTypes.string.isRequired,
   onBackdropPress: PropTypes.func.isRequired,
+  onTransitionEnd: PropTypes.func.isRequired,
 };
 
 DrawerContainer.styles = ({ drawer: theme }) => {
@@ -123,6 +127,8 @@ DrawerContainer.styles = ({ drawer: theme }) => {
       height: '100%',
       display: 'inline',
       position: 'absolute',
+      boxSizing: 'border-box',
+      backgroundColor: theme.drawerBgColor,
       top: 0,
       left: -theme.drawerWidth,
       bottom: 0,

--- a/src/components/drawer/drawer-container.spec.js
+++ b/src/components/drawer/drawer-container.spec.js
@@ -14,6 +14,7 @@ const defaultProps = {
   opened: false,
   drawerPosition: 'left',
   onBackdropPress: () => {},
+  onTransitionEnd: () => {},
 };
 
 test('should render div with the class of drawer', (t) => {

--- a/src/components/drawer/drawer.jsx
+++ b/src/components/drawer/drawer.jsx
@@ -99,6 +99,8 @@ export default class Drawer extends PureComponent {
     window.removeEventListener('resize', this.handleResize);
   }
 
+  backdropFinishedTransitioning = false;
+
   /**
    * Open the SideNav when the drawer is in narrow mode.
    */
@@ -142,9 +144,19 @@ export default class Drawer extends PureComponent {
    * Close the drawer upon backdrop press.
    */
   handleBackdropPress = () => {
-    if (this.props.closeOnBackdropClick) {
+    if (this.props.closeOnBackdropClick && this.backdropFinishedTransitioning) {
       this.close();
     }
+  };
+
+  /**
+   * Toggle the backdropFinishedTransitioning when the backdrop finishes the transition.
+   * This fixes a bug we're on mobile the drawer would immediately close after opening it
+   * because the mouse event after the touch event would fire on the backdrop
+   * and not the actual clicked element.
+   */
+  handleTransitionEnd = () => {
+    this.backdropFinishedTransitioning = !this.backdropFinishedTransitioning;
   };
 
   render() {
@@ -165,6 +177,7 @@ export default class Drawer extends PureComponent {
         opened={this.state.opened}
         drawerPosition={drawerPosition}
         onBackdropPress={this.handleBackdropPress}
+        onTransitionEnd={this.handleTransitionEnd}
       />
     );
   }

--- a/src/components/drawer/drawer.jsx
+++ b/src/components/drawer/drawer.jsx
@@ -50,7 +50,7 @@ export default class Drawer extends PureComponent {
     backdrop: true,
     drawerPosition: 'left',
     onNarrowChange: () => {},
-    closeOnBackdropClick: true,
+    closeOnBackdropClick: false,
   };
 
   static MainContent = MainContent;

--- a/src/components/drawer/drawer.spec.js
+++ b/src/components/drawer/drawer.spec.js
@@ -116,7 +116,7 @@ test('should update the narrow state when the window resizes', (t) => {
   t.deepEqual(wrapper.state('isNarrow'), true);
 });
 
-test('should set the opened state to false when the backdrop click handler get\'s called', (t) => {
+test('should not close the drawer when the prop closeOnBackdropClick is false', (t) => {
   const wrapper = shallow(
     <Drawer closeOnBackdropClick={false}>
       <MainContent>Test</MainContent>
@@ -129,10 +129,37 @@ test('should set the opened state to false when the backdrop click handler get\'
 
   instance.handleBackdropPress();
 
-  // Should not change the state because closeOnBackdropClick was false
   t.deepEqual(wrapper.state('opened'), true);
+});
 
-  wrapper.setProps({ closeOnBackdropClick: true });
+test('should not close the drawer when the backdrop hasn\'t finished transitioning', (t) => {
+  const wrapper = shallow(
+    <Drawer closeOnBackdropClick>
+      <MainContent>Test</MainContent>
+      <DrawerContent>Test</DrawerContent>
+    </Drawer>,
+  );
+  const instance = wrapper.instance();
+
+  instance.open();
+
+  instance.handleBackdropPress();
+
+  t.deepEqual(wrapper.state('opened'), true);
+});
+
+test('should close the drawer when the backdrop has finished transitioning and is clicked', (t) => {
+  const wrapper = shallow(
+    <Drawer closeOnBackdropClick>
+      <MainContent>Test</MainContent>
+      <DrawerContent>Test</DrawerContent>
+    </Drawer>,
+  );
+  const instance = wrapper.instance();
+
+  instance.open();
+
+  instance.handleTransitionEnd();
 
   instance.handleBackdropPress();
 

--- a/src/components/drawer/stories.jsx
+++ b/src/components/drawer/stories.jsx
@@ -1,15 +1,67 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import Drawer from './drawer';
 import DrawerContent from './drawer-content';
 import MainContent from './main-content';
+import IconButton from '../icon-button';
+
+/**
+ * A component which creates a fully working drawer for the story.
+ *
+ * @class
+ */
+class DrawerStory extends PureComponent {
+  /**
+   * When the close icon inside the drawer is pressed we want to close the drawer.
+   */
+  handleDrawerClose = () => {
+    this.drawer.close();
+  };
+
+  /**
+   * When the menu icon button is pressed we want to open the drawer.
+   */
+  handleDrawerOpen = () => {
+    this.drawer.open();
+  };
+
+  render() {
+    return (
+      <Drawer
+        {...this.props}
+        style={{ flex: 1 }}
+        ref={(element) => { this.drawer = element; }}
+      >
+        <DrawerContent style={{ padding: 32 }}>
+          Drawer Content
+
+          <IconButton
+            icon="close"
+            onPress={this.handleDrawerClose}
+          />
+        </DrawerContent>
+
+        <MainContent style={{ padding: 32 }}>
+          Main Content
+
+          <IconButton
+            icon="menu"
+            onPress={this.handleDrawerOpen}
+          />
+        </MainContent>
+      </Drawer>
+    );
+  }
+}
 
 storiesOf('Drawer', module)
-  .add('Default styles', () => (
-    <Drawer drawerPosition="right">
-      <DrawerContent>Drawer Content</DrawerContent>
-
-      <MainContent>Main Content</MainContent>
-    </Drawer>
+  .add('Left Drawer', () => (
+    <DrawerStory />
+  ))
+  .add('Right Drawer', () => (
+    <DrawerStory drawerPosition="right" />
+  ))
+  .add('Custom responsive width', () => (
+    <DrawerStory responsiveWidth={1000} />
   ));

--- a/src/components/drawer/theme.js
+++ b/src/components/drawer/theme.js
@@ -5,6 +5,7 @@ export const schema = PropTypes.shape({
   backdropActiveOpacity: PropTypes.number,
   backdropBgColor: PropTypes.string,
   transitionDuration: PropTypes.number,
+  drawerBgColor: PropTypes.string.isRequired,
 });
 
 /**
@@ -19,5 +20,6 @@ export function defaultTheme() {
     backdropActiveOpacity: 0.5,
     backdropBgColor: '#000000',
     transitionDuration: 250,
+    drawerBgColor: '#ffffff',
   };
 }


### PR DESCRIPTION
Fixed a few bugs with the Drawer component such as:
- Immediately closing the drawer after opening it because of the backdrop
- Set boxSizing to 'border-box' for when the drawer has some padding. Earlier this would show the drawer slightly as the padding get's added on top of the width
- Added a default backgroundColor to the drawer so it's not transparent without any extra styles